### PR TITLE
Padding modifications to container and label classes/elements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,6 +1,7 @@
 .search{
     margin-top: -7%;
     padding: 8rem 0 7rem;
+    padding-bottom: 15px;
     text-align: center;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -47,12 +47,16 @@ label{
   font-family: Garmond;
   font-size: large;
   color: white;
+  padding-right: 10px;
 }
 table, th, td{
     color: white;
    width: 75%;
    margin-left: auto;
    margin-right: auto;
+}
+.container {
+  padding-bottom: 50px;
 }
 </style>
 


### PR DESCRIPTION
Having noticed that the food results per dining hall went all the way to the dead bottom of the page with no padding, I added in a padding-bottom value of 50px so that there's a bit of spacing, making the last elements of the list a bit easier to read (especially on a computer/laptop screen). Also added some padding to the "Search..." label so it is further from touching the search bar.

These are basically aesthetic changes, feel free to modify this or leave comments as you see fit.